### PR TITLE
Fixed auto setup of MySQL/MariaDB - Issue #25

### DIFF
--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -66,6 +66,7 @@ RUN apt-get upgrade -qy && apt-get install -qy \
     wget \
     unzip \
     sed \
+    mysql-client \
     && a2enmod ssl \
     && a2enmod rewrite \
     && a2enmod headers \
@@ -93,17 +94,21 @@ COPY 02_auto_update.sh ${start_scripts_path}
 COPY 03_set_a2port.sh ${start_scripts_path}
 COPY 04_enable_REMOTE_USER.sh ${start_scripts_path}
 COPY 05_switch_http_https.sh ${start_scripts_path}
+COPY 06_initialize_db.sh ${start_scripts_path}
 COPY start.sh /start.sh
 RUN chmod +x ${start_scripts_path}/01_user_config.sh \
     && chmod +x ${start_scripts_path}/02_auto_update.sh \
     && chmod +x ${start_scripts_path}/03_set_a2port.sh \
     && chmod +x ${start_scripts_path}/04_enable_REMOTE_USER.sh \
     && chmod +x ${start_scripts_path}/05_switch_http_https.sh \
+    && chmod +x ${start_scripts_path}/06_initialize_db.sh \
     && chmod +x /start.sh
 
 CMD ["./start.sh"]
 
 ADD Auth.php /Auth.php
+ADD config.ini.php /config.ini.php
+ADD webtrees.sql /webtrees.sql
        
 #Add Apache configuration
 ADD php.ini /etc/php/7.2/apache2/

--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ This image contains now the necessary libraries to optionally also select Postgr
 * **2020/08/11:** Webtrees 2.0.7 - Fixed documentation, removed separate media folder from v1.x and updated module path for version v2.x.
 * **2020/10/04:** Webtrees 2.0.8
 * **2020/10/10:** Webtrees 2.0.9
+* **2020/10/18:** Webtrees 2.0.9 - Fixed auto setup of MySQL/MariaDB. (Added missing files - Issue #25)


### PR DESCRIPTION
This fixes the Issue #25. It added the missing files also during the build in the Travis CI pipeline.
Further cleanup should be performed to remove old Docker build files.