### PR TITLE
Comment out webtree 1.x specific volume mount

### DIFF
--- a/kubernetes/webtrees-deployment.yaml
+++ b/kubernetes/webtrees-deployment.yaml
@@ -71,9 +71,10 @@ spec:
         - name: webtrees-persistent-storage
           mountPath: /var/www/html/data
           subPath: data
-        - name: webtrees-persistent-storage
-          mountPath: /var/www/html/media
-          subPath: media
+# Uncomment below items if you are still using webtree 1.x
+#        - name: webtrees-persistent-storage
+#          mountPath: /var/www/html/media
+#          subPath: media
       volumes:
       - name: webtrees-persistent-storage
         persistentVolumeClaim:


### PR DESCRIPTION
Since webtrees 2.x, the media folder is inside the data folder. So only the data folder is needed

See: https://github.com/H2CK/webtrees/issues/22