### PR TITLE
Update yaml files so they are valid for k8s v1.20

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -4,4 +4,20 @@ This example template for kubernetes automatically creates a MySQL 5.7 database 
 Webtrees will be provided without SSL on port 80.
 The template uses a persitent volume claim. Therefore your K8S instance has to provide a perstitant_storage.
 
+When you modify kustomization.yaml, your password values must be base64 encoded. You can use the base64 command line tool to generate these values. For example:
+
+```text
+echo myactualpassword | base64
+```
+
+The resulting text is what you need to put into the yaml file.
+
 You can apply the (modified) template using the command `kubectl apply -f kustomization.yaml`.
+
+Then apply the mysql and webtrees files:
+
+```text
+kubectl apply -f mysql-deployment.yaml
+kubectl apply -f webtrees-deployment.yaml
+```
+

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -1,11 +1,15 @@
-secretGenerator:
-- name: mysql-pass
-  literals:
-  - password=YOUR_PASSWORD
-- name: webtrees-admin-pass
-  literals:
-  - password=YOUR_WEBTREES_ADMIN_PASSWORD
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-pass
+type: Opaque
+data:
+  password: YOUR_PASSWORD
 ---
-resources:
-- mysql-deployment.yaml
-- wwebtrees-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webtrees-admin-pass
+type: Opaque
+data:
+  password: YOUR_WEBTREES_ADMIN_PASSWORD

--- a/kubernetes/mysql-deployment.yaml
+++ b/kubernetes/mysql-deployment.yaml
@@ -59,6 +59,8 @@ spec:
         volumeMounts:
         - name: mysql-persistent-storage
           mountPath: /var/lib/mysql
+      nodeSelector:
+        kubernetes.io/arch: amd64
       volumes:
       - name: mysql-persistent-storage
         persistentVolumeClaim:

--- a/kubernetes/webtrees-deployment.yaml
+++ b/kubernetes/webtrees-deployment.yaml
@@ -35,25 +35,23 @@ spec:
   selector:
     matchLabels:
       app: webtrees
-      tier: frontend
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         app: webtrees
-        tier: frontend
     spec:
       containers:
       - image: dtjs48jkt/webtrees
         name: webtrees
         env:
         - name: DISABLE_SSL
-          value: true
+          value: "true"
         - name: PORT
-          value: 80
+          value: "80"
         - name: DB_HOST
-          value: webtrees-mysql
+          value: "webtrees-mysql"
         - name: WT_ADMINPW
           valueFrom:
             secretKeyRef:
@@ -75,6 +73,8 @@ spec:
 #        - name: webtrees-persistent-storage
 #          mountPath: /var/www/html/media
 #          subPath: media
+      nodeSelector:
+        kubernetes.io/arch: amd64
       volumes:
       - name: webtrees-persistent-storage
         persistentVolumeClaim:

--- a/kubernetes/webtrees-deployment.yaml
+++ b/kubernetes/webtrees-deployment.yaml
@@ -73,8 +73,6 @@ spec:
 #        - name: webtrees-persistent-storage
 #          mountPath: /var/www/html/media
 #          subPath: media
-      nodeSelector:
-        kubernetes.io/arch: amd64
       volumes:
       - name: webtrees-persistent-storage
         persistentVolumeClaim:


### PR DESCRIPTION
In attempting to use the yaml files to install to my k8s cluster, I ran into some yaml validation issues against the current version of Kubernetes. I have attempted to address these issues in this PR.

Changes include:

1. Adding nodeSelector for amd64, because these images can't run on an arm64 node
2. Fix numerous cases where "=" was used instead of ": " as a separator
3. Updated `kustomization.yaml` to be valid yaml for k8s
4. Updated the readme to reflect the changes, plus instructions about making the password values base64 as required by k8s

These changes did allow the yaml files to be applied to my cluster, and both pods are running. I remain unable to actually connect to the webtrees site, so I don't think that the webtrees container actually _works_, but at least these updates get the containers deployed into pods.
